### PR TITLE
fix build failed

### DIFF
--- a/pkg/controllers/notification.go
+++ b/pkg/controllers/notification.go
@@ -318,6 +318,8 @@ func sendEvent(resp *http.Response, eventType event.Name) error {
 
 			for _, endpoint := range resource.Endpoints {
 				celeryClient.Delay("worker.send_event", endpoint.URI, string(value))
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
```
[vagrant@admin kaoliang]$ go build main.go 
# github.com/inwinstack/kaoliang/vendor/github.com/ceph/go-ceph/rados
cgo-gcc-prolog: In function ‘_cgo_8e4c4ad409ba_Cfunc_rados_read_op_omap_get_vals’:
cgo-gcc-prolog:520:2: warning: ‘rados_read_op_omap_get_vals’ is deprecated (declared at /usr/include/rados/librados.h:3272) [-Wdeprecated-declarations]
# github.com/inwinstack/kaoliang/pkg/controllers
pkg/controllers/notification.go:326:6: syntax error: unexpected isMultipartUpload, expecting (
pkg/controllers/notification.go:331:6: syntax error: unexpected IsAdminUserPath, expecting (
pkg/controllers/notification.go:335:6: syntax error: unexpected ReverseProxy, expecting (
pkg/controllers/notification.go:386:6: syntax error: unexpected getBucketUsers, expecting (
pkg/controllers/notification.go:405:6: syntax error: unexpected contains, expecting (
```