### PR TITLE
change authenticate function to return full user id which contains subuser id

### DIFF
--- a/pkg/controllers/mdsearch.go
+++ b/pkg/controllers/mdsearch.go
@@ -103,6 +103,11 @@ func Search(c *gin.Context) {
 		return
 	}
 
+	tokens := strings.Split(userID, ":")
+	if len(tokens) > 1 {
+		userID = tokens[0]
+	}
+
 	bucket := c.Param("bucket")
 	users, ok := getBucketUsers(bucket)
 	if !ok {

--- a/pkg/controllers/notification.go
+++ b/pkg/controllers/notification.go
@@ -67,6 +67,11 @@ func GetBucketNotification(c *gin.Context) {
 		return
 	}
 
+	tokens := strings.Split(userID, ":")
+	if len(tokens) > 1 {
+		userID = tokens[0]
+	}
+
 	bucket := c.Param("bucket")
 	users, ok := getBucketUsers(bucket)
 	if !ok {
@@ -99,6 +104,11 @@ func PutBucketNotification(c *gin.Context) {
 	if errCode != cmd.ErrNone {
 		writeErrorResponse(c, errCode)
 		return
+	}
+
+	tokens := strings.Split(userID, ":")
+	if len(tokens) > 1 {
+		userID = tokens[0]
 	}
 
 	bucket := c.Param("bucket")

--- a/pkg/controllers/queue.go
+++ b/pkg/controllers/queue.go
@@ -37,6 +37,11 @@ func ListQueues(c *gin.Context) {
 		return
 	}
 
+	tokens := strings.Split(accountID, ":")
+	if len(tokens) > 1 {
+		accountID = tokens[0]
+	}
+
 	db := models.GetDB()
 	var queues []models.Resource
 	db.Where(&models.Resource{
@@ -63,6 +68,11 @@ func CreateQueue(c *gin.Context) {
 	if errCode != cmd.ErrNone {
 		writeErrorResponse(c, errCode)
 		return
+	}
+
+	tokens := strings.Split(accountID, ":")
+	if len(tokens) > 1 {
+		accountID = tokens[0]
 	}
 
 	var queueName string
@@ -122,6 +132,11 @@ func DeleteQueue(c *gin.Context) {
 		return
 	}
 
+	tokens := strings.Split(userID, ":")
+	if len(tokens) > 1 {
+		userID = tokens[0]
+	}
+
 	var accountID string
 	var queueName string
 	switch c.Request.Method {
@@ -169,6 +184,11 @@ func ReceiveMessage(c *gin.Context) {
 	if errCode != cmd.ErrNone {
 		writeErrorResponse(c, errCode)
 		return
+	}
+
+	tokens := strings.Split(userID, ":")
+	if len(tokens) > 1 {
+		userID = tokens[0]
 	}
 
 	var accountID string

--- a/pkg/controllers/topic.go
+++ b/pkg/controllers/topic.go
@@ -17,6 +17,7 @@ package controllers
 import (
 	"net/http"
 	"regexp"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/minio/minio/cmd"
@@ -30,6 +31,11 @@ func CreateTopic(c *gin.Context) {
 	if errCode != cmd.ErrNone {
 		writeErrorResponse(c, errCode)
 		return
+	}
+
+	tokens := strings.Split(accountID, ":")
+	if len(tokens) > 1 {
+		accountID = tokens[0]
 	}
 
 	topicName := c.PostForm("Name")
@@ -69,6 +75,11 @@ func ListTopics(c *gin.Context) {
 		return
 	}
 
+	tokens := strings.Split(accountID, ":")
+	if len(tokens) > 1 {
+		accountID = tokens[0]
+	}
+
 	db := models.GetDB()
 	topics := []models.Resource{}
 	db.Where(&models.Resource{
@@ -95,6 +106,11 @@ func DeleteTopic(c *gin.Context) {
 	if errCode != cmd.ErrNone {
 		writeErrorResponse(c, errCode)
 		return
+	}
+
+	tokens := strings.Split(userID, ":")
+	if len(tokens) > 1 {
+		userID = tokens[0]
 	}
 
 	topicARN := c.PostForm("TopicArn")
@@ -131,6 +147,11 @@ func Subscribe(c *gin.Context) {
 		return
 	}
 
+	tokens := strings.Split(accountID, ":")
+	if len(tokens) > 1 {
+		accountID = tokens[0]
+	}
+
 	endpointURI := c.PostForm("Endpoint")
 	protocol := c.PostForm("Protocol")
 	topicARN := c.PostForm("TopicArn")
@@ -162,6 +183,11 @@ func ListSubscriptions(c *gin.Context) {
 	if errCode != cmd.ErrNone {
 		writeErrorResponse(c, errCode)
 		return
+	}
+
+	tokens := strings.Split(accountID, ":")
+	if len(tokens) > 1 {
+		accountID = tokens[0]
 	}
 
 	topics := []models.Resource{}
@@ -198,6 +224,11 @@ func Unsubscribe(c *gin.Context) {
 	if errCode != cmd.ErrNone {
 		writeErrorResponse(c, errCode)
 		return
+	}
+
+	tokens := strings.Split(accountID, ":")
+	if len(tokens) > 1 {
+		accountID = tokens[0]
 	}
 
 	subscriptionARN := c.PostForm("SubscriptionArn")

--- a/vendor/github.com/minio/minio/cmd/signature-v4.go
+++ b/vendor/github.com/minio/minio/cmd/signature-v4.go
@@ -396,6 +396,7 @@ func GetCredentials(accessKey string) (string, auth.Credentials, APIErrorCode) {
 
 func getCredentials(accessKey string) (string, auth.Credentials, APIErrorCode) {
 	type Key struct {
+		User      string `json:"user"`
 		AccessKey string `json:"access_key"`
 		SecretKey string `json:"secret_key"`
 	}
@@ -425,7 +426,7 @@ func getCredentials(accessKey string) (string, auth.Credentials, APIErrorCode) {
 
 	for _, key := range userInfo.Keys {
 		if key.AccessKey == accessKey {
-			return userID, auth.Credentials{
+			return key.User, auth.Credentials{
 				AccessKey: key.AccessKey,
 				SecretKey: key.SecretKey,
 			}, ErrNone


### PR DESCRIPTION
```
[root@mon-1 kaoliang]# grep -rnw . -e 'authenticate'                                                                                                                                      
./pkg/controllers/auth.go:25:func authenticate(r *http.Request) (string, cmd.APIErrorCode) {
./pkg/controllers/queue.go:34:  accountID, errCode := authenticate(c.Request)
./pkg/controllers/queue.go:62:  accountID, errCode := authenticate(c.Request)
./pkg/controllers/queue.go:119: userID, errCode := authenticate(c.Request)
./pkg/controllers/queue.go:168: userID, errCode := authenticate(c.Request)
./pkg/controllers/topic.go:29:  accountID, errCode := authenticate(c.Request)
./pkg/controllers/topic.go:66:  accountID, errCode := authenticate(c.Request)
./pkg/controllers/topic.go:94:  userID, errCode := authenticate(c.Request)
./pkg/controllers/topic.go:128: accountID, errCode := authenticate(c.Request)
./pkg/controllers/topic.go:161: accountID, errCode := authenticate(c.Request)
./pkg/controllers/topic.go:197: accountID, errCode := authenticate(c.Request)
./pkg/controllers/notification.go:64:   userID, errCode := authenticate(c.Request)
./pkg/controllers/notification.go:98:   userID, errCode := authenticate(c.Request)
./pkg/controllers/mdsearch.go:100:      userID, errCode := authenticate(c.Request)
Binary file ./sns/sns matches
Binary file ./sqs/sqs matches
./vendor/github.com/garyburd/redigo/redis/pool.go:85:// Use the Dial function to authenticate connections with the AUTH command or
./vendor/github.com/gin-gonic/gin/context.go:126:// For example, a failed attempt to authenticate a request could use: context.AbortWithStatus(401).
./vendor/github.com/godbus/dbus/auth.go:127:// tryAuth tries to authenticate with m as the mechanism, using state as the
./vendor/github.com/gomodule/redigo/redis/pool.go:85:// Use the Dial function to authenticate connections with the AUTH command or
./vendor/github.com/minio/highwayhash/README.md:8:It can be used to prevent hash-flooding attacks or authenticate short-lived messages. Additionally it can be used as a fingerprinting function. HighwayHash is not a general purpose cryptographic hash function (such as Blake2b, SHA-3 or SHA-2) and should not be used if strong collision resistance is required. 
./vendor/github.com/minio/highwayhash/highwayhash.go:7:// or to authenticate short-lived messages.
./vendor/github.com/minio/sio/README.md:23:authenticate data. Any modification to the encrypted data (ciphertext) is detected while
./vendor/github.com/olivere/elastic/reindex.go:531:// Username sets the username to authenticate with the remote cluster.
./vendor/github.com/olivere/elastic/reindex.go:537:// Password sets the password to authenticate with the remote cluster.
./vendor/gopkg.in/olivere/elastic.v5/reindex.go:531:// Username sets the username to authenticate with the remote cluster.
./vendor/gopkg.in/olivere/elastic.v5/reindex.go:537:// Password sets the password to authenticate with the remote cluster.
```