### PR TITLE
Avoid duplicate config

### DIFF
--- a/pkg/controllers/ganesha.go
+++ b/pkg/controllers/ganesha.go
@@ -256,7 +256,7 @@ func removeNfsExportObj(ioctx *rados.IOContext, exportObjName string) {
 	ioctx.Delete(exportObjName)
 }
 
-func HandleNfsExport(req *http.Request, body []byte) {
+func HandleNfsExport(req *http.Request, body []byte, statusCode int) {
 	_, isSubuser := req.URL.Query()["subuser"]
 	_, isKey := req.URL.Query()["key"]
 	_, isQuota := req.URL.Query()["quota"]
@@ -267,11 +267,12 @@ func HandleNfsExport(req *http.Request, body []byte) {
 	}
 
 	// handle create user
-	if req.Method == "PUT" {
+	if req.Method == "PUT" && statusCode == 200 {
 		addNfsExport(body)
 		return
 	}
-	if req.Method == "DELETE" {
+	// handle delete user even if user is not exists
+	if req.Method == "DELETE" && (statusCode == 200 || statusCode == 404) {
 		uid, _ := req.URL.Query()["uid"]
 		removeNfsExport(uid[0])
 		return

--- a/pkg/controllers/notification.go
+++ b/pkg/controllers/notification.go
@@ -348,10 +348,11 @@ func ReverseProxy() gin.HandlerFunc {
 			clientReq := resp.Request
 			go LoggingOps(resp)
 			switch {
-			case IsAdminUserPath(clientReq.URL.Path) && resp.StatusCode == 200:
+			case IsAdminUserPath(clientReq.URL.Path):
+				statusCode := resp.StatusCode
 				b, _ := ioutil.ReadAll(resp.Body)
 				resp.Body.Close()
-				go HandleNfsExport(clientReq, b)
+				go HandleNfsExport(clientReq, b, statusCode)
 				resp.Body = ioutil.NopCloser(bytes.NewReader(b)) // put body back for client response
 				return nil
 			case len(clientReq.Header["X-Amz-Copy-Source"]) > 0 && cfg.EnableKaoliangCopy == "True":

--- a/pkg/controllers/ops_logging.go
+++ b/pkg/controllers/ops_logging.go
@@ -147,7 +147,10 @@ func LoggingOps(resp *http.Response) {
 	conn.ReadDefaultConfigFile()
 	conn.Connect()
 	defer conn.Shutdown()
-	ioctx, _ := conn.OpenIOContext(poolName)
+	ioctx, err := conn.OpenIOContext(poolName)
+	if err != nil {
+		return	
+	}
 	defer ioctx.Destroy()
 
 	ioctx.Append(logObjName, data)


### PR DESCRIPTION
try to remove nfs-ganesha export config when delete user api return 404 (user is not exists),
it should be avoid the config duplication if user has been removed without api or proxy crash.